### PR TITLE
Define pretty-print

### DIFF
--- a/src/UnicodeGraphics.jl
+++ b/src/UnicodeGraphics.jl
@@ -5,6 +5,13 @@ module UnicodeGraphics
 
 export blockize, brailize, blockize!, brailize!
 
+struct UnicodeGraphicsType
+    data::String
+end
+function Base.show(io::IO, x::UnicodeGraphicsType)
+    print(io, x.data)
+end
+
 """
     brailize(a, cutoff=0)
 Convert an array to a block unicode string, filling values above the cutoff point.
@@ -12,7 +19,7 @@ Convert an array to a block unicode string, filling values above the cutoff poin
 blockize(a, cutoff=0) = begin
     yrange, xrange = axes(a)
     out = Array{Char,2}(undef, length(xrange) + 1, (length(yrange) - 1) ÷ 2 + 1)
-    blockize!(out, a, cutoff) 
+    blockize!(out, a, cutoff)
 end
 
 """
@@ -25,7 +32,7 @@ yrange, xrange = axes(a)
 out = Array{Char,2}(undef, length(xrange) + 1, (length(yrange) - 1) ÷ 2 + 1)
 ```
 """
-blockize!(out, a, cutoff=0) = join(block_array!(out, a, cutoff))
+blockize!(out, a, cutoff=0) = join(block_array!(out, a, cutoff)) |> UnicodeGraphicsType
 
 function block_array!(out, a, cutoff)
     yrange, xrange = axes(a)
@@ -54,10 +61,10 @@ const braile_hex = ((0x01, 0x08), (0x02, 0x10), (0x04, 0x20), (0x40, 0x80))
     brailize(a, cutoff=0)
 Convert an array to a braile unicode string, filling values above the cutoff point.
 """
-brailize(a, cutoff=0) = begin 
+brailize(a, cutoff=0) = begin
     yrange, xrange = axes(a)
     out = Array{Char,2}(undef, (length(xrange) - 1) ÷ 2 + 2, (length(yrange) - 1) ÷ 4 + 1)
-    brailize!(out, a, cutoff) 
+    brailize!(out, a, cutoff)
 end
 
 """
@@ -70,7 +77,7 @@ yrange, xrange = axes(a)
 out = Array{Char,2}(undef, (length(xrange) - 1) ÷ 2 + 2, (length(yrange) - 1) ÷ 4 + 1)
 ```
 """
-brailize!(out, a, cutoff=0) = join(braile_array!(out, a, cutoff))
+brailize!(out, a, cutoff=0) = join(braile_array!(out, a, cutoff)) |> UnicodeGraphicsType
 
 function braile_array!(out, a, cutoff)
     yrange, xrange = axes(a)

--- a/src/UnicodeGraphics.jl
+++ b/src/UnicodeGraphics.jl
@@ -5,11 +5,36 @@ module UnicodeGraphics
 
 export blockize, brailize, blockize!, brailize!
 
-struct UnicodeGraphicsType
-    data::String
+# ref: LaTeXStrings.jl, https://github.com/stevengj/LaTeXStrings.jl/tree/v1.0.3
+struct UnicodeGraphicsString <: AbstractString
+    s::String
 end
-function Base.show(io::IO, x::UnicodeGraphicsType)
-    print(io, x.data)
+Base.write(io::IO, s::UnicodeGraphicsString) = write(io, s.s)
+Base.firstindex(s::UnicodeGraphicsString) = firstindex(s.s)
+Base.lastindex(s::UnicodeGraphicsString) = lastindex(s.s)
+Base.iterate(s::UnicodeGraphicsString, i::Int) = iterate(s.s, i)
+Base.iterate(s::UnicodeGraphicsString) = iterate(s.s)
+Base.nextind(s::UnicodeGraphicsString, i::Int) = nextind(s.s, i)
+Base.prevind(s::UnicodeGraphicsString, i::Int) = prevind(s.s, i)
+Base.eachindex(s::UnicodeGraphicsString) = eachindex(s.s)
+Base.length(s::UnicodeGraphicsString) = length(s.s)
+Base.getindex(s::UnicodeGraphicsString, i::Integer) = getindex(s.s, i)
+Base.getindex(s::UnicodeGraphicsString, i::Int) = getindex(s.s, i)
+Base.getindex(s::UnicodeGraphicsString, i::UnitRange{Int}) = getindex(s.s, i)
+Base.getindex(s::UnicodeGraphicsString, i::UnitRange{<:Integer}) = getindex(s.s, i)
+Base.getindex(s::UnicodeGraphicsString, i::AbstractVector{<:Integer}) = getindex(s.s, i)
+Base.codeunit(s::UnicodeGraphicsString, i::Integer) = codeunit(s.s, i)
+Base.codeunit(s::UnicodeGraphicsString) = codeunit(s.s)
+Base.ncodeunits(s::UnicodeGraphicsString) = ncodeunits(s.s)
+Base.codeunits(s::UnicodeGraphicsString) = codeunits(s.s)
+Base.sizeof(s::UnicodeGraphicsString) = sizeof(s.s)
+Base.isvalid(s::UnicodeGraphicsString, i::Integer) = isvalid(s.s, i)
+Base.pointer(s::UnicodeGraphicsString) = pointer(s.s)
+Base.IOBuffer(s::UnicodeGraphicsString) = IOBuffer(s.s)
+Base.unsafe_convert(T::Union{Type{Ptr{UInt8}},Type{Ptr{Int8}},Cstring}, s::UnicodeGraphicsString) = Base.unsafe_convert(T, s.s)
+
+function Base.show(io::IO, s::UnicodeGraphicsString)
+    print(io, s.s)
 end
 
 """
@@ -32,7 +57,7 @@ yrange, xrange = axes(a)
 out = Array{Char,2}(undef, length(xrange) + 1, (length(yrange) - 1) ÷ 2 + 1)
 ```
 """
-blockize!(out, a, cutoff=0) = join(block_array!(out, a, cutoff)) |> UnicodeGraphicsType
+blockize!(out, a, cutoff=0) = join(block_array!(out, a, cutoff)) |> UnicodeGraphicsString
 
 function block_array!(out, a, cutoff)
     yrange, xrange = axes(a)
@@ -77,7 +102,7 @@ yrange, xrange = axes(a)
 out = Array{Char,2}(undef, (length(xrange) - 1) ÷ 2 + 2, (length(yrange) - 1) ÷ 4 + 1)
 ```
 """
-brailize!(out, a, cutoff=0) = join(braile_array!(out, a, cutoff)) |> UnicodeGraphicsType
+brailize!(out, a, cutoff=0) = join(braile_array!(out, a, cutoff)) |> UnicodeGraphicsString
 
 function braile_array!(out, a, cutoff)
     yrange, xrange = axes(a)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using UnicodeGraphics, 
+using UnicodeGraphics,
       OffsetArrays,
       Test
 
@@ -98,3 +98,15 @@ braile_ghost =
 test_ghost = sprint(show, brailize(OffsetArray(ghost[2:15, 4:17], 2:15, 4:17), 0.5))
 @test test_ghost == braile_ghost
 println(test_ghost, "\n\n", braile_ghost)
+
+test_ghost = blockize(OffsetArray(ghost[3:15, 4:17], 3:15, 4:17), 0.5)
+@test ccall(:strlen, Csize_t, (Cstring,), test_ghost[1:prevind(test_ghost, lastindex(test_ghost))]) == ccall(:strlen, Csize_t, (Ptr{UInt8},), test_ghost) == sizeof(test_ghost)-1
+for f in (length, eachindex, pointer, collect, ncodeunits, codeunits)
+    @test f(test_ghost) == f(test_ghost.s)
+end
+@test nextind(test_ghost, 1) == prevind(test_ghost, 3) == 2
+@test isvalid(test_ghost, 1)
+@test findnext(isequal('▄'), test_ghost, 1) == 4
+@test test_ghost[4] == '▄'
+@test codeunit(test_ghost, 1) == UInt8(' ')
+@test test_ghost[1:4] == test_ghost[0x01:0x04] == test_ghost[[1,2,3,4]] == "   ▄"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,7 +36,7 @@ block_pac = """
   ▀██████████████▀  
      ▀▀██████▀▀     \0"""
 
-test_pac = blockize(pac)
+test_pac = sprint(show, blockize(pac))
 @test test_pac == block_pac
 println(test_pac, "\n\n", block_pac, "\n\n")
 
@@ -49,7 +49,7 @@ brail_pac =
 ⠹⣿⣿⣿⣿⣿⣿⣷⣦⡄
 ⠀⠙⠻⢿⣿⣿⡿⠟⠋⠀\0"""
 
-test_pac = brailize(pac)
+test_pac = sprint(show, brailize(pac))
 @test test_pac == brail_pac
 println(test_pac, "\n\n", brail_pac, "\n\n")
 
@@ -83,7 +83,7 @@ block_ghost =
 ██▀███▀▀███▀██
 ▀   ▀▀  ▀▀   ▀\0"""
 
-test_ghost = blockize(OffsetArray(ghost[3:15, 4:17], 3:15, 4:17), 0.5, )
+test_ghost = sprint(show, blockize(OffsetArray(ghost[3:15, 4:17], 3:15, 4:17), 0.5))
 @test test_ghost == block_ghost
 println(test_ghost, "\n\n", block_ghost, "\n\n")
 
@@ -95,6 +95,6 @@ braile_ghost =
 ⣿⣶⣿⣿⣶⣿⣿
 ⠋⠈⠛⠀⠛⠁⠙\0"""
 
-test_ghost = brailize(OffsetArray(ghost[2:15, 4:17], 2:15, 4:17), 0.5)
+test_ghost = sprint(show, brailize(OffsetArray(ghost[2:15, 4:17], 2:15, 4:17), 0.5))
 @test test_ghost == braile_ghost
 println(test_ghost, "\n\n", braile_ghost)


### PR DESCRIPTION
I define pretty-print to omit `print` statement. Of course, it also support `print`.

![pacman](https://user-images.githubusercontent.com/21122112/46402299-51405000-c73a-11e8-898b-78b9c21ff73e.png)
